### PR TITLE
Added empty state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-23.0.2
-    - android-23
+    - build-tools-25.0.0
+    - android-25
     - extra-android-support
     - extra-android-m2repository
     - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "io.github.luizgrp.sectionedrecyclerviewadapter.demo"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 31 09:54:39 IST 2016
+#Wed May 31 01:30:51 SGT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ ext {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 11

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/Section.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/Section.java
@@ -10,7 +10,7 @@ import android.view.View;
  */
 public abstract class Section {
 
-    public enum State { LOADING, LOADED, FAILED}
+    public enum State { LOADING, LOADED, FAILED, EMPTY }
 
     private State state = State.LOADED;
 
@@ -26,6 +26,7 @@ public abstract class Section {
 
     private Integer loadingResourceId;
     private Integer failedResourceId;
+    private Integer emptyResourceId;
 
     /**
      * Package-level constructor
@@ -39,11 +40,13 @@ public abstract class Section {
      * @param itemResourceId layout resource for its items
      * @param loadingResourceId layout resource for its loading state
      * @param failedResourceId layout resource for its failed state
+     * @param emptyResourceId layout resource for its empty state
      */
-    public Section(int itemResourceId, int loadingResourceId, int failedResourceId) {
+    public Section(int itemResourceId, int loadingResourceId, int failedResourceId, int emptyResourceId) {
         this.itemResourceId = itemResourceId;
         this.loadingResourceId = loadingResourceId;
         this.failedResourceId = failedResourceId;
+        this.emptyResourceId = emptyResourceId;
     }
 
     /**
@@ -52,9 +55,10 @@ public abstract class Section {
      * @param itemResourceId layout resource for its items
      * @param loadingResourceId layout resource for its loading state
      * @param failedResourceId layout resource for its failed state
+     * @param emptyResourceId layout resource for its empty state
      */
-    public Section(int headerResourceId, int itemResourceId, int loadingResourceId, int failedResourceId) {
-        this(itemResourceId, loadingResourceId, failedResourceId);
+    public Section(int headerResourceId, int itemResourceId, int loadingResourceId, int failedResourceId, int emptyResourceId) {
+        this(itemResourceId, loadingResourceId, failedResourceId, emptyResourceId);
         this.headerResourceId = headerResourceId;
         hasHeader = true;
     }
@@ -66,9 +70,10 @@ public abstract class Section {
      * @param itemResourceId layout resource for its items
      * @param loadingResourceId layout resource for its loading state
      * @param failedResourceId layout resource for its failed state
+     * @param emptyResourceId layout resource for its empty state
      */
-    public Section(int headerResourceId, int footerResourceId, int itemResourceId, int loadingResourceId, int failedResourceId) {
-        this(headerResourceId, itemResourceId, loadingResourceId, failedResourceId);
+    public Section(int headerResourceId, int footerResourceId, int itemResourceId, int loadingResourceId, int failedResourceId, int emptyResourceId) {
+        this(headerResourceId, itemResourceId, loadingResourceId, failedResourceId, emptyResourceId);
         this.footerResourceId = footerResourceId;
         hasFooter = true;
     }
@@ -178,6 +183,14 @@ public abstract class Section {
     }
 
     /**
+     * Return the layout resource id of the empty view
+     * @return layout resource id of the empty view
+     */
+    public final Integer getEmptyResourceId() {
+        return emptyResourceId;
+    }
+
+    /**
      * Bind the data to the ViewHolder for the Content of this Section, that can be the Items,
      * Loading view or Failed view, depending on the current state of the section
      * @param holder ViewHolder for the Content of this Section
@@ -193,6 +206,9 @@ public abstract class Section {
                 break;
             case FAILED:
                 onBindFailedViewHolder(holder);
+                break;
+            case EMPTY:
+                onBindEmptyViewHolder(holder);
                 break;
             default:
                 throw new IllegalStateException("Invalid state");
@@ -215,6 +231,9 @@ public abstract class Section {
                 contentItemsTotal = getContentItemsTotal();
                 break;
             case FAILED:
+                contentItemsTotal = 1;
+                break;
+            case EMPTY:
                 contentItemsTotal = 1;
                 break;
             default:
@@ -306,6 +325,22 @@ public abstract class Section {
      * @param holder ViewHolder for the Failed state of this Section
      */
     public void onBindFailedViewHolder(RecyclerView.ViewHolder holder) {
+        // Nothing to bind here.
+    }
+
+    /**
+     * Return the ViewHolder for the Empty state of this Section
+     * @param view View inflated by resource returned by getItemResourceId
+     * @return ViewHolder for the Empty of this Section
+     */
+    public RecyclerView.ViewHolder getEmptyViewHolder(View view) {
+        return new SectionedRecyclerViewAdapter.EmptyViewHolder(view);
+    }
+    /**
+     * Bind the data to the ViewHolder for the Empty state of this Section
+     * @param holder ViewHolder for the Empty state of this Section
+     */
+    public void onBindEmptyViewHolder(RecyclerView.ViewHolder holder) {
         // Nothing to bind here.
     }
 }

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -424,6 +424,33 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     }
 
     /**
+     * Return the section position in the adapter.
+     *
+     * @param section This section
+     * @return position of the section in the adapter
+     */
+    public int getSectionPosition(Section section) {
+        int currentPos = 0;
+
+        for (Map.Entry<String, Section> entry : sections.entrySet()) {
+            Section s = entry.getValue();
+
+            // ignore invisible sections
+            if (!s.isVisible()) continue;
+
+            int sectionTotal = s.getSectionItemsTotal();
+
+            if (s == section) {
+                return currentPos;
+            }
+
+            currentPos += sectionTotal;
+        }
+
+        throw new IllegalArgumentException("Invalid section");
+    }
+
+    /**
      * Return a map with all sections of this adapter.
      *
      * @return a map with all sections
@@ -442,7 +469,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemInsertedInSection(String tag, int position) {
         Section section = getValidSectionOrThrowException(tag);
 
-        callSuperNotifyItemInserted(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + position);
+        notifyItemInsertedInSection(section, position);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
+     *
+     * @param section This section
+     * @param position position of the item in the section
+     */
+    public void notifyItemInsertedInSection(Section section, int position) {
+        callSuperNotifyItemInserted(getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -583,6 +583,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
         callSuperNotifyItemRangeRemoved(getAdapterPosition(tag, positionStart), itemCount);
     }
 
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeRemoved notifyItemRangeRemoved}.
+     *
+     * @param section this section
+     * @param positionStart previous position of the first item that was removed from the section
+     * @param itemCount number of items removed from the section
+     */
+    public void notifyItemRangeRemovedFromSection(Section section, int positionStart, int itemCount) {
+        callSuperNotifyItemRangeRemoved(getAdapterPosition(section, positionStart), itemCount);
+    }
+
     @VisibleForTesting
     void callSuperNotifyItemRangeRemoved(int positionStart, int itemCount) {
         super.notifyItemRangeRemoved(positionStart, itemCount);

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -453,10 +453,10 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      * @return position of the item in the adapter
      */
-    public int getAdapterPosition(String tag, int position) {
+    public int getPositionInAdapter(String tag, int position) {
         Section section = getValidSectionOrThrowException(tag);
 
-        return getAdapterPosition(section, position);
+        return getPositionInAdapter(section, position);
     }
 
     /**
@@ -467,7 +467,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      * @return position of the item in the adapter
      */
-    public int getAdapterPosition(Section section, int position) {
+    public int getPositionInAdapter(Section section, int position) {
         return getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position;
     }
 
@@ -479,7 +479,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(String tag, int position) {
-        callSuperNotifyItemInserted(getAdapterPosition(tag, position));
+        callSuperNotifyItemInserted(getPositionInAdapter(tag, position));
     }
 
     /**
@@ -490,7 +490,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(Section section, int position) {
-        callSuperNotifyItemInserted(getAdapterPosition(section, position));
+        callSuperNotifyItemInserted(getPositionInAdapter(section, position));
     }
 
     @VisibleForTesting
@@ -508,7 +508,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeInsertedInSection(String tag, int positionStart, int itemCount) {
         callSuperNotifyItemRangeInserted(
-                getAdapterPosition(tag, positionStart), itemCount);
+                getPositionInAdapter(tag, positionStart), itemCount);
     }
 
     /**
@@ -521,7 +521,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeInsertedInSection(Section section, int positionStart, int itemCount) {
         callSuperNotifyItemRangeInserted(
-                getAdapterPosition(section, positionStart), itemCount);
+                getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -537,7 +537,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemRemovedFromSection(String tag, int position) {
-        callSuperNotifyItemRemoved(getAdapterPosition(tag, position));
+        callSuperNotifyItemRemoved(getPositionInAdapter(tag, position));
     }
 
     /**
@@ -548,7 +548,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemRemovedFromSection(Section section, int position) {
-        callSuperNotifyItemRemoved(getAdapterPosition(section, position));
+        callSuperNotifyItemRemoved(getPositionInAdapter(section, position));
     }
 
     @VisibleForTesting
@@ -565,7 +565,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items removed from the section
      */
     public void notifyItemRangeRemovedFromSection(String tag, int positionStart, int itemCount) {
-        callSuperNotifyItemRangeRemoved(getAdapterPosition(tag, positionStart), itemCount);
+        callSuperNotifyItemRangeRemoved(getPositionInAdapter(tag, positionStart), itemCount);
     }
 
     /**
@@ -577,7 +577,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items removed from the section
      */
     public void notifyItemRangeRemovedFromSection(Section section, int positionStart, int itemCount) {
-        callSuperNotifyItemRangeRemoved(getAdapterPosition(section, positionStart), itemCount);
+        callSuperNotifyItemRangeRemoved(getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -593,7 +593,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemChangedInSection(String tag, int position) {
-        callSuperNotifyItemChanged(getAdapterPosition(tag, position));
+        callSuperNotifyItemChanged(getPositionInAdapter(tag, position));
     }
 
     /**
@@ -604,7 +604,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemChangedInSection(Section section, int position) {
-        callSuperNotifyItemChanged(getAdapterPosition(section, position));
+        callSuperNotifyItemChanged(getPositionInAdapter(section, position));
     }
 
     @VisibleForTesting
@@ -622,7 +622,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount) {
         callSuperNotifyItemRangeChanged(
-                getAdapterPosition(tag, positionStart), itemCount);
+                getPositionInAdapter(tag, positionStart), itemCount);
     }
 
     /**
@@ -635,7 +635,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount) {
         callSuperNotifyItemRangeChanged(
-                getAdapterPosition(section, positionStart), itemCount);
+                getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -655,7 +655,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount,
                                                 Object payload) {
         callSuperNotifyItemRangeChanged(
-                getAdapterPosition(tag, positionStart), itemCount,
+                getPositionInAdapter(tag, positionStart), itemCount,
                 payload);
     }
 
@@ -671,7 +671,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount,
                                                 Object payload) {
         callSuperNotifyItemRangeChanged(
-                getAdapterPosition(section, positionStart), itemCount,
+                getPositionInAdapter(section, positionStart), itemCount,
                 payload);
     }
 
@@ -689,8 +689,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param toPosition new position of the item in the section
      */
     public void notifyItemMovedInSection(String tag, int fromPosition, int toPosition) {
-        callSuperNotifyItemMoved(getAdapterPosition(tag, fromPosition),
-                getAdapterPosition(tag, toPosition));
+        callSuperNotifyItemMoved(getPositionInAdapter(tag, fromPosition),
+                getPositionInAdapter(tag, toPosition));
     }
 
     /**
@@ -702,8 +702,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param toPosition new position of the item in the section
      */
     public void notifyItemMovedInSection(Section section, int fromPosition, int toPosition) {
-        callSuperNotifyItemMoved(getAdapterPosition(section, fromPosition),
-                getAdapterPosition(section, toPosition));
+        callSuperNotifyItemMoved(getPositionInAdapter(section, fromPosition),
+                getPositionInAdapter(section, toPosition));
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -476,7 +476,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * Helper method that receives position in relation to the section, calculates the relative
      * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
      *
-     * @param section This section
+     * @param section this section
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(Section section, int position) {
@@ -518,7 +518,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemRemovedFromSection(String tag, int position) {
         Section section = getValidSectionOrThrowException(tag);
 
-        callSuperNotifyItemRemoved(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + position);
+        notifyItemRemovedFromSection(section, position);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRemoved notifyItemRemoved}.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     */
+    public void notifyItemRemovedFromSection(Section section, int position) {
+        callSuperNotifyItemRemoved(getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -674,6 +674,22 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
                 payload);
     }
 
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeChanged notifyItemRangeChanged}.
+     *
+     * @param section this section
+     * @param positionStart position of the first item that was inserted in the section
+     * @param itemCount number of items inserted in the section
+     * @param payload optional parameter, use null to identify a "full" update
+     */
+    public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount,
+                                                Object payload) {
+        callSuperNotifyItemRangeChanged(
+                getAdapterPosition(section, positionStart), itemCount,
+                payload);
+    }
+
     @VisibleForTesting
     void callSuperNotifyItemRangeChanged(int positionStart, int itemCount, Object payload) {
         super.notifyItemRangeChanged(positionStart, itemCount, payload);

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -473,6 +473,32 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     }
 
     /**
+     * Helper method that receives position in relation to the section, and returns the position in
+     * the adapter.
+     *
+     * @param tag unique identifier of the section
+     * @param position position of the item in the section
+     * @return position of the item in the adapter
+     */
+    public int getAdapterPosition(String tag, int position) {
+        Section section = getValidSectionOrThrowException(tag);
+
+        return getAdapterPosition(section, position);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, and returns the position in
+     * the adapter.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     * @return position of the item in the adapter
+     */
+    public int getAdapterPosition(Section section, int position) {
+        return getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position;
+    }
+
+    /**
      * Helper method that receives position in relation to the section, calculates the relative
      * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
      *
@@ -480,7 +506,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(Section section, int position) {
-        callSuperNotifyItemInserted(getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position);
+        callSuperNotifyItemInserted(getAdapterPosition(section, position));
     }
 
     @VisibleForTesting
@@ -529,7 +555,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemRemovedFromSection(Section section, int position) {
-        callSuperNotifyItemRemoved(getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position);
+        callSuperNotifyItemRemoved(getAdapterPosition(section, position));
     }
 
     @VisibleForTesting
@@ -599,7 +625,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount) {
         callSuperNotifyItemRangeChanged(
-                getSectionPosition(section) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+                getAdapterPosition(section, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -653,8 +679,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param toPosition new position of the item in the section
      */
     public void notifyItemMovedInSection(Section section, int fromPosition, int toPosition) {
-        callSuperNotifyItemMoved(getSectionPosition(section) + (section.hasHeader ? 1 : 0) + fromPosition,
-                getSectionPosition(section) + (section.hasHeader ? 1 : 0) + toPosition);
+        callSuperNotifyItemMoved(getAdapterPosition(section, fromPosition),
+                getAdapterPosition(section, toPosition));
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -25,11 +25,12 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public final static int VIEW_TYPE_ITEM_LOADED = 2;
     public final static int VIEW_TYPE_LOADING = 3;
     public final static int VIEW_TYPE_FAILED = 4;
+    public final static int VIEW_TYPE_EMPTY = 5;
 
     private LinkedHashMap<String, Section> sections;
     private HashMap<String, Integer> sectionViewTypeNumbers;
     private int viewTypeCount = 0;
-    private final static int VIEW_TYPE_QTY = 5;
+    private final static int VIEW_TYPE_QTY = 6;
 
     public SectionedRecyclerViewAdapter() {
         sections = new LinkedHashMap<>();
@@ -65,6 +66,10 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
                     }
                     case VIEW_TYPE_FAILED: {
                         viewHolder = getFailedViewHolder(parent, section);
+                        break;
+                    }
+                    case VIEW_TYPE_EMPTY: {
+                        viewHolder = getEmptyViewHolder(parent, section);
                         break;
                     }
                     default:
@@ -123,6 +128,16 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
         View view = LayoutInflater.from(parent.getContext()).inflate(resId, parent, false);
         // get the failed load viewholder from the section
         return section.getFailedViewHolder(view);
+    }
+
+    private RecyclerView.ViewHolder getEmptyViewHolder(ViewGroup parent, Section section) {
+        Integer resId = section.getEmptyResourceId();
+
+        if (resId == null) throw new NullPointerException("Missing 'empty state' resource id");
+
+        View view = LayoutInflater.from(parent.getContext()).inflate(resId, parent, false);
+        // get the empty load viewholder from the section
+        return section.getEmptyViewHolder(view);
     }
 
     /**
@@ -240,12 +255,13 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     @Override
     public int getItemViewType(int position) {
         /*
-         Each Section has 5 "viewtypes":
+         Each Section has 6 "viewtypes":
          1) header
          2) footer
          3) items
          4) loading
          5) load failed
+         6) empty
          */
         int currentPos = 0;
 
@@ -281,6 +297,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
                         return viewType + 3;
                     case FAILED:
                         return viewType + 4;
+                    case EMPTY:
+                        return viewType + 5;
                     default:
                         throw new IllegalStateException("Invalid state");
                 }
@@ -301,10 +319,11 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * - SectionedRecyclerViewAdapter.VIEW_TYPE_ITEM_LOADED
      * - SectionedRecyclerViewAdapter.VIEW_TYPE_LOADING
      * - SectionedRecyclerViewAdapter.VIEW_TYPE_FAILED
+     * - SectionedRecyclerViewAdapter.VIEW_TYPE_EMPTY
      *
      * @param position position in the adapter
      * @return SectionedRecyclerViewAdapter.VIEW_TYPE_HEADER, VIEW_TYPE_FOOTER,
-     * VIEW_TYPE_ITEM_LOADED, VIEW_TYPE_LOADING or VIEW_TYPE_FAILED
+     * VIEW_TYPE_ITEM_LOADED, VIEW_TYPE_LOADING VIEW_TYPE_FAILED or VIEW_TYPE_EMPTY
      */
     public int getSectionItemViewType(int position) {
         int viewType = getItemViewType(position);

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -459,16 +459,6 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
         return sections;
     }
 
-    /**
-     * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
-     *
-     * @param tag unique identifier of the section
-     * @param position position of the item in the section
-     */
-    public void notifyItemInsertedInSection(String tag, int position) {
-        callSuperNotifyItemInserted(getAdapterPosition(tag, position));
-    }
 
     /**
      * Helper method that receives position in relation to the section, and returns the position in
@@ -500,6 +490,17 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * Helper method that receives position in relation to the section, calculates the relative
      * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
      *
+     * @param tag unique identifier of the section
+     * @param position position of the item in the section
+     */
+    public void notifyItemInsertedInSection(String tag, int position) {
+        callSuperNotifyItemInserted(getAdapterPosition(tag, position));
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
+     *
      * @param section this section
      * @param position position of the item in the section
      */
@@ -523,6 +524,19 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemRangeInsertedInSection(String tag, int positionStart, int itemCount) {
         callSuperNotifyItemRangeInserted(
                 getAdapterPosition(tag, positionStart), itemCount);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeInserted notifyItemRangeInserted}.
+     *
+     * @param section this section
+     * @param positionStart position of the first item that was inserted in the section
+     * @param itemCount number of items inserted in the section
+     */
+    public void notifyItemRangeInsertedInSection(Section section, int positionStart, int itemCount) {
+        callSuperNotifyItemRangeInserted(
+                getAdapterPosition(section, positionStart), itemCount);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -629,8 +629,20 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemMovedInSection(String tag, int fromPosition, int toPosition) {
         Section section = getValidSectionOrThrowException(tag);
 
-        callSuperNotifyItemMoved(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + fromPosition,
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + toPosition);
+        notifyItemMovedInSection(section, fromPosition, toPosition);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemMoved notifyItemMoved}.
+     *
+     * @param section this section
+     * @param fromPosition previous position of the item in the section
+     * @param toPosition new position of the item in the section
+     */
+    public void notifyItemMovedInSection(Section section, int fromPosition, int toPosition) {
+        callSuperNotifyItemMoved(getSectionPosition(section) + (section.hasHeader ? 1 : 0) + fromPosition,
+                getSectionPosition(section) + (section.hasHeader ? 1 : 0) + toPosition);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -403,24 +403,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @return position of the section in the adapter
      */
     public int getSectionPosition(String tag) {
-        int currentPos = 0;
+        Section section = getValidSectionOrThrowException(tag);
 
-        for (Map.Entry<String, Section> entry : sections.entrySet()) {
-            Section section = entry.getValue();
-
-            // ignore invisible sections
-            if (!section.isVisible()) continue;
-
-            int sectionTotal = section.getSectionItemsTotal();
-
-            if (entry.getKey().equalsIgnoreCase(tag)) {
-                return currentPos;
-            }
-
-            currentPos += sectionTotal;
-        }
-
-        throw new IllegalArgumentException("Invalid tag: " + tag);
+        return getSectionPosition(section);
     }
 
     /**

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -467,9 +467,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(String tag, int position) {
-        Section section = getValidSectionOrThrowException(tag);
-
-        notifyItemInsertedInSection(section, position);
+        callSuperNotifyItemInserted(getAdapterPosition(tag, position));
     }
 
     /**
@@ -523,10 +521,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items inserted in the section
      */
     public void notifyItemRangeInsertedInSection(String tag, int positionStart, int itemCount) {
-        Section section = getValidSectionOrThrowException(tag);
-
         callSuperNotifyItemRangeInserted(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+                getAdapterPosition(tag, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -542,9 +538,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemRemovedFromSection(String tag, int position) {
-        Section section = getValidSectionOrThrowException(tag);
-
-        notifyItemRemovedFromSection(section, position);
+        callSuperNotifyItemRemoved(getAdapterPosition(tag, position));
     }
 
     /**
@@ -572,10 +566,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items removed from the section
      */
     public void notifyItemRangeRemovedFromSection(String tag, int positionStart, int itemCount) {
-        Section section = getValidSectionOrThrowException(tag);
-
-        callSuperNotifyItemRangeRemoved(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+        callSuperNotifyItemRangeRemoved(getAdapterPosition(tag, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -591,9 +582,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemChangedInSection(String tag, int position) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemChanged(getAdapterPosition(tag, position));
+    }
 
-        callSuperNotifyItemChanged(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + position);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemChanged notifyItemChanged}.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     */
+    public void notifyItemChangedInSection(Section section, int position) {
+        callSuperNotifyItemChanged(getAdapterPosition(section, position));
     }
 
     @VisibleForTesting
@@ -610,9 +610,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items inserted in the section
      */
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount) {
-        Section section = getValidSectionOrThrowException(tag);
-
-        notifyItemRangeChangedInSection(section, positionStart, itemCount);
+        callSuperNotifyItemRangeChanged(
+                getAdapterPosition(tag, positionStart), itemCount);
     }
 
     /**
@@ -644,10 +643,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount,
                                                 Object payload) {
-        Section section = getValidSectionOrThrowException(tag);
-
         callSuperNotifyItemRangeChanged(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount,
+                getAdapterPosition(tag, positionStart), itemCount,
                 payload);
     }
 
@@ -665,9 +662,8 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param toPosition new position of the item in the section
      */
     public void notifyItemMovedInSection(String tag, int fromPosition, int toPosition) {
-        Section section = getValidSectionOrThrowException(tag);
-
-        notifyItemMovedInSection(section, fromPosition, toPosition);
+        callSuperNotifyItemMoved(getAdapterPosition(tag, fromPosition),
+                getAdapterPosition(tag, toPosition));
     }
 
     /**

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -586,8 +586,20 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount) {
         Section section = getValidSectionOrThrowException(tag);
 
+        notifyItemRangeChangedInSection(section, positionStart, itemCount);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeChanged notifyItemRangeChanged}.
+     *
+     * @param section this section
+     * @param positionStart position of the first item that was inserted in the section
+     * @param itemCount number of items inserted in the section
+     */
+    public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount) {
         callSuperNotifyItemRangeChanged(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+                getSectionPosition(section) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/StatelessSection.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/StatelessSection.java
@@ -61,4 +61,14 @@ public abstract class StatelessSection extends Section {
     public final RecyclerView.ViewHolder getFailedViewHolder(View view) {
         return super.getFailedViewHolder(view);
     }
+
+    @Override
+    public final void onBindEmptyViewHolder(RecyclerView.ViewHolder holder) {
+        super.onBindEmptyViewHolder(holder);
+    }
+
+    @Override
+    public final RecyclerView.ViewHolder getEmptyViewHolder(View view) {
+        return super.getEmptyViewHolder(view);
+    }
 }

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -528,7 +528,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemChangedInSection_withAdapterWithManySections_callsSuperNotifyItemChangedInSection() {
+    public void notifyItemChangedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemChangedInSection() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(anyInt());
@@ -541,6 +541,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(11);
+    }
+
+    @Test
+    public void notifyItemRangeChangedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(headedFootedStatelessSectionStub, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4);
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -657,7 +657,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeChangedInSectionWithPayload_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+    public void notifyItemRangeChangedInSectionWithPayloadUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt(), any());
@@ -667,6 +667,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(SECTION_TAG, 0, 4, null);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4, null);
+    }
+
+    @Test
+    public void notifyItemRangeChangedInSectionWithPayloadUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt(), any());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(headedFootedStatelessSectionStub, 0, 4, null);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4, null);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -576,7 +576,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemMovedInSection_withAdapterWithManySections_callsSuperNotifyItemMoved() {
+    public void notifyItemMovedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemMoved() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(anyInt(), anyInt());
@@ -586,6 +586,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemMovedInSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(11, 15);
+    }
+
+    @Test
+    public void notifyItemMovedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemMoved() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemMovedInSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(11, 15);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -126,7 +126,7 @@ public class SectionedRecyclerViewAdapterTest {
         // Then
         assertThat(result, is(10));
     }
-    
+
     @Test(expected = IndexOutOfBoundsException.class)
     public void onBindViewHolder_withEmptyAdapter_throwsException() {
         // When
@@ -464,7 +464,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void getAdapterPositionUsingTag_withAdapterWithManySections_returnsCorrectAdapterPosition() {
+    public void getPositionInAdapterUsingTag_withAdapterWithManySections_returnsCorrectAdapterPosition() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
@@ -473,11 +473,11 @@ public class SectionedRecyclerViewAdapterTest {
         spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, new HeadedFootedStatelessSectionStub(ITEMS_QTY));
 
         // When
-        assertEquals(11, spySectionedRecyclerViewAdapter.getAdapterPosition(SECTION_TAG, 0));
+        assertEquals(11, spySectionedRecyclerViewAdapter.getPositionInAdapter(SECTION_TAG, 0));
     }
 
     @Test
-    public void getAdapterPositionUsingSection_withAdapterWithManySections_returnsCorrectAdapterPosition() {
+    public void getPositionInAdapterUsingSection_withAdapterWithManySections_returnsCorrectAdapterPosition() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
@@ -487,7 +487,7 @@ public class SectionedRecyclerViewAdapterTest {
         spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
-        assertEquals(11, spySectionedRecyclerViewAdapter.getAdapterPosition(headedFootedStatelessSectionStub, 0));
+        assertEquals(11, spySectionedRecyclerViewAdapter.getPositionInAdapter(headedFootedStatelessSectionStub, 0));
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -479,7 +479,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRemovedFromSection_withAdapterWithManySections_callsSuperNotifyItemRemoved() {
+    public void notifyItemRemovedFromSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRemoved() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(anyInt());
@@ -489,6 +489,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRemovedFromSection(SECTION_TAG, 0);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(11);
+    }
+
+    @Test
+    public void notifyItemRemovedFromSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRemoved() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRemovedFromSection(headedFootedStatelessSectionStub, 0);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(11);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -430,7 +430,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemInsertedInSection_withAdapterWithManySections_callsSuperNotifyItemInserted() {
+    public void notifyItemInsertedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemInserted() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
@@ -440,6 +440,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemInsertedInSection(SECTION_TAG, 0);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(11);
+    }
+
+    @Test
+    public void notifyItemInsertedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemInserted() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemInsertedInSection(headedFootedStatelessSectionStub, 0);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(11);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -66,13 +66,13 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getSectionPosition_withEmptyAdapter_throwsException() {
+    public void getSectionPositionUsingTag_withEmptyAdapter_throwsException() {
         // When
         sectionAdapter.getSectionPosition(SECTION_TAG);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getSectionPosition_withInvalidTag_throwsException() {
+    public void getSectionPositionUsingTag_withInvalidTag_throwsException() {
         // Given
         addStatelessSectionStubToAdapter();
         addStatelessSectionStubToAdapter();
@@ -82,7 +82,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void getSectionPosition_withAdapterWithInvisibleSection_returnsCorrectPosition() {
+    public void getSectionPositionUsingTag_withAdapterWithInvisibleSection_returnsCorrectPosition() {
         // Given
         addStatelessSectionStubToAdapter();
 
@@ -95,6 +95,38 @@ public class SectionedRecyclerViewAdapterTest {
         assertThat(result, is(10));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void getSectionPositionUsingSection_withEmptyAdapter_throwsException() {
+        // When
+        sectionAdapter.getSectionPosition(new StatelessSectionStub(ITEMS_QTY));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getSectionPositionUsingSection_withInvalidTag_throwsException() {
+        // Given
+        addStatelessSectionStubToAdapter();
+        addStatelessSectionStubToAdapter();
+
+        // When
+        sectionAdapter.getSectionPosition(new StatelessSectionStub(ITEMS_QTY));
+    }
+
+    @Test
+    public void getSectionPositionUsingSection_withAdapterWithInvisibleSection_returnsCorrectPosition() {
+        // Given
+        addStatelessSectionStubToAdapter();
+
+        StatelessSectionStub statelessSectionStub = new StatelessSectionStub(ITEMS_QTY);
+
+        sectionAdapter.addSection(statelessSectionStub);
+
+        // When
+        int result = sectionAdapter.getSectionPosition(statelessSectionStub);
+
+        // Then
+        assertThat(result, is(10));
+    }
+    
     @Test(expected = IndexOutOfBoundsException.class)
     public void onBindViewHolder_withEmptyAdapter_throwsException() {
         // When

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -558,7 +558,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeRemovedInSection_withAdapterWithManySections_callsSuperNotifyItemRangeRemoved() {
+    public void notifyItemRangeRemovedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeRemoved() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(anyInt(), anyInt());
@@ -568,6 +568,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeRemovedFromSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(11, 4);
+    }
+
+    @Test
+    public void notifyItemRangeRemovedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeRemoved() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeRemovedFromSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(11, 4);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -452,7 +452,7 @@ public class SectionedRecyclerViewAdapterTest {
 
         spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
         HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
-        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
         assertEquals(11, spySectionedRecyclerViewAdapter.getAdapterPosition(headedFootedStatelessSectionStub, 0));
@@ -482,7 +482,7 @@ public class SectionedRecyclerViewAdapterTest {
 
         spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
         HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
-        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemInsertedInSection(headedFootedStatelessSectionStub, 0);
@@ -492,7 +492,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeInsertedInSection_withAdapterWithManySections_callsSuperNotifyItemRangeInserted() {
+    public void notifyItemRangeInsertedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeInserted() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(anyInt(), anyInt());
@@ -502,6 +502,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeInsertedInSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(11, 4);
+    }
+
+    @Test
+    public void notifyItemRangeInsertedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeInserted() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeInsertedInSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(11, 4);
@@ -531,7 +548,7 @@ public class SectionedRecyclerViewAdapterTest {
 
         spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
         HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
-        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRemovedFromSection(headedFootedStatelessSectionStub, 0);
@@ -580,7 +597,7 @@ public class SectionedRecyclerViewAdapterTest {
 
         spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
         HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
-        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemChangedInSection(headedFootedStatelessSectionStub, 0);
@@ -597,7 +614,7 @@ public class SectionedRecyclerViewAdapterTest {
 
         spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
         HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
-        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(headedFootedStatelessSectionStub, 0, 4);
@@ -662,7 +679,7 @@ public class SectionedRecyclerViewAdapterTest {
 
         spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
         HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
-        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemMovedInSection(headedFootedStatelessSectionStub, 0, 4);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -573,6 +573,23 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
+    public void notifyItemChangedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemChangedInSection() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemChangedInSection(headedFootedStatelessSectionStub, 0);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(11);
+    }
+
+    @Test
     public void notifyItemRangeChangedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
@@ -590,7 +607,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeChangedInSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+    public void notifyItemRangeChangedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt());

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -292,10 +292,10 @@ public class SectionedRecyclerViewAdapterTest {
         int positionFooter = sectionAdapter.getItemViewType(43);
 
         // Then
-        assertThat(positionHeader, is(15));
-        assertThat(positionItemStart, is(17));
-        assertThat(positionItemEnd, is(17));
-        assertThat(positionFooter, is(16));
+        assertThat(positionHeader, is(18));
+        assertThat(positionItemStart, is(20));
+        assertThat(positionItemEnd, is(20));
+        assertThat(positionFooter, is(19));
     }
 
     @Test
@@ -317,7 +317,7 @@ public class SectionedRecyclerViewAdapterTest {
         int positionLoading = sectionAdapter.getItemViewType(44);
 
         // Then
-        assertThat(positionLoading, is(23));
+        assertThat(positionLoading, is(27));
     }
 
     @Test
@@ -339,7 +339,7 @@ public class SectionedRecyclerViewAdapterTest {
         int positionFailed = sectionAdapter.getItemViewType(44);
 
         // Then
-        assertThat(positionFailed, is(24));
+        assertThat(positionFailed, is(28));
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -342,6 +342,27 @@ public class SectionedRecyclerViewAdapterTest {
         assertThat(positionFailed, is(28));
     }
 
+    public void getItemViewType_withAdapterWithManySections_returnsCorrectValuesForSectionWithEmptyState() {
+        // Given
+        addStatelessSectionStubToAdapter();
+        addHeadedStatelessSectionStubToAdapter();
+        addFootedStatelessSectionStubToAdapter();
+        addHeadedFootedStatelessSectionStubToAdapter();
+
+        Section section = addSectionStubToAdapter();
+        section.setState(Section.State.EMPTY);
+
+        addHeadedSectionStubToAdapter();
+        addFootedSectionStubToAdapter();
+        addHeadedFootedSectionStubToAdapter();
+
+        // When
+        int positionFailed = sectionAdapter.getItemViewType(44);
+
+        // Then
+        assertThat(positionFailed, is(29));
+    }
+
     @Test
     public void onCreateViewHolder_withEmptyAdapter_returnsNull() {
         // When
@@ -384,6 +405,15 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         sectionAdapter.onCreateViewHolder(null, SectionedRecyclerViewAdapter.VIEW_TYPE_FAILED);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onCreateViewHolder_withStatelessSection_throwsExceptionForEmpty() {
+        // Given
+        addStatelessSectionStubToAdapter();
+
+        // When
+        sectionAdapter.onCreateViewHolder(null, SectionedRecyclerViewAdapter.VIEW_TYPE_EMPTY);
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -12,6 +12,8 @@ import io.github.luizgrp.sectionedrecyclerviewadapter.testdoubles.stub.HeadedSta
 import io.github.luizgrp.sectionedrecyclerviewadapter.testdoubles.stub.SectionStub;
 import io.github.luizgrp.sectionedrecyclerviewadapter.testdoubles.stub.StatelessSectionStub;
 
+import static org.junit.Assert.assertEquals;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -427,6 +429,33 @@ public class SectionedRecyclerViewAdapterTest {
         // Then
         assertThat(sectionAdapter.getItemCount(), is(0));
         assertTrue(sectionAdapter.getSectionsMap().isEmpty());
+    }
+
+    @Test
+    public void getAdapterPositionUsingTag_withAdapterWithManySections_returnsCorrectAdapterPosition() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, new HeadedFootedStatelessSectionStub(ITEMS_QTY));
+
+        // When
+        assertEquals(11, spySectionedRecyclerViewAdapter.getAdapterPosition(SECTION_TAG, 0));
+    }
+
+    @Test
+    public void getAdapterPositionUsingSection_withAdapterWithManySections_returnsCorrectAdapterPosition() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, headedFootedStatelessSectionStub);
+
+        // When
+        assertEquals(11, spySectionedRecyclerViewAdapter.getAdapterPosition(headedFootedStatelessSectionStub, 0));
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingFootedSectionSpy.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingFootedSectionSpy.java
@@ -18,7 +18,7 @@ public class BindingFootedSectionSpy extends Section {
     final int contentItemsTotal;
 
     public BindingFootedSectionSpy(int contentItemsTotal) {
-        super(-1, -1, -1, -1 , -1);
+        super(-1, -1, -1, -1 , -1, -1);
 
         // remove header
         this.setHasHeader(false);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingHeadedFootedSectionSpy.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingHeadedFootedSectionSpy.java
@@ -19,7 +19,7 @@ public class BindingHeadedFootedSectionSpy extends Section {
     final int contentItemsTotal;
 
     public BindingHeadedFootedSectionSpy(int contentItemsTotal) {
-        super(-1, -1, -1, -1, -1);
+        super(-1, -1, -1, -1, -1, -1);
 
         this.contentItemsTotal = contentItemsTotal;
     }

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingHeadedSectionSpy.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingHeadedSectionSpy.java
@@ -18,7 +18,7 @@ public class BindingHeadedSectionSpy extends Section {
     final int contentItemsTotal;
 
     public BindingHeadedSectionSpy(int contentItemsTotal) {
-        super(-1, -1, -1 ,-1);
+        super(-1, -1, -1 ,-1, -1);
 
         this.contentItemsTotal = contentItemsTotal;
     }

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingSectionSpy.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/spy/BindingSectionSpy.java
@@ -17,7 +17,7 @@ public class BindingSectionSpy extends Section {
     final int contentItemsTotal;
 
     public BindingSectionSpy(int contentItemsTotal) {
-        super(-1, -1, -1);
+        super(-1, -1, -1, -1);
 
         this.contentItemsTotal = contentItemsTotal;
     }

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/stub/SectionStub.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/testdoubles/stub/SectionStub.java
@@ -13,7 +13,7 @@ public class SectionStub extends Section {
     final int contentItemsTotal;
 
     public SectionStub(int contentItemsTotal) {
-        super(-1, -1, -1);
+        super(-1, -1, -1, -1);
 
         this.contentItemsTotal = contentItemsTotal;
     }


### PR DESCRIPTION
Sometimes, when there are no items in a section, there can be 2 possibilities.

1. Loading error like internet problem. Hence, it makes sense to provide FAILED state. We can show an UI with retry button.

2. But, it can also be, a valid EMPTY state. For instance, user doesn't save anything in Settings. Hence, it makes sense loader returns empty result from Settings. In that case, we need a different type of view. View for FAILED state is not suitable in this case.

p/s Or, when user explicitly remove all items from the Section. It make sense, to let caller have a choice, whether to switch the Section's state to EMPTY, when there is no content item in the Section.