### PR TITLE
Section as method parameter

### DIFF
--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -460,9 +460,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(String tag, int position) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemInserted(getPositionInAdapter(tag, position));
+    }
 
-        callSuperNotifyItemInserted(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + position);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     */
+    public void notifyItemInsertedInSection(Section section, int position) {
+        callSuperNotifyItemInserted(getPositionInAdapter(section, position));
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -662,12 +662,21 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param toPosition new position of the item in the section
      */
     public void notifyItemMovedInSection(String tag, int fromPosition, int toPosition) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemMoved(getPositionInAdapter(tag, fromPosition),
+                getPositionInAdapter(tag, toPosition));
+    }
 
-        int sectionPosition = getSectionPosition(tag);
-
-        callSuperNotifyItemMoved(sectionPosition + (section.hasHeader ? 1 : 0) + fromPosition,
-                sectionPosition + (section.hasHeader ? 1 : 0) + toPosition);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemMoved}.
+     *
+     * @param section this section
+     * @param fromPosition previous position of the item in the section
+     * @param toPosition new position of the item in the section
+     */
+    public void notifyItemMovedInSection(Section section, int fromPosition, int toPosition) {
+        callSuperNotifyItemMoved(getPositionInAdapter(section, fromPosition),
+                getPositionInAdapter(section, toPosition));
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -546,10 +546,19 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items removed from the section
      */
     public void notifyItemRangeRemovedFromSection(String tag, int positionStart, int itemCount) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemRangeRemoved(getPositionInAdapter(tag, positionStart), itemCount);
+    }
 
-        callSuperNotifyItemRangeRemoved(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeRemoved notifyItemRangeRemoved}.
+     *
+     * @param section this section
+     * @param positionStart previous position of the first item that was removed from the section
+     * @param itemCount number of items removed from the section
+     */
+    public void notifyItemRangeRemovedFromSection(Section section, int positionStart, int itemCount) {
+        callSuperNotifyItemRangeRemoved(getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -488,10 +488,21 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items inserted in the section
      */
     public void notifyItemRangeInsertedInSection(String tag, int positionStart, int itemCount) {
-        Section section = getValidSectionOrThrowException(tag);
-
         callSuperNotifyItemRangeInserted(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+                getPositionInAdapter(tag, positionStart), itemCount);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeInserted notifyItemRangeInserted}.
+     *
+     * @param section this section
+     * @param positionStart position of the first item that was inserted in the section
+     * @param itemCount number of items inserted in the section
+     */
+    public void notifyItemRangeInsertedInSection(Section section, int positionStart, int itemCount) {
+        callSuperNotifyItemRangeInserted(
+                getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -631,11 +631,21 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      */
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount,
                                                 Object payload) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemRangeChanged(getPositionInAdapter(tag, positionStart), itemCount, payload);
+    }
 
-        callSuperNotifyItemRangeChanged(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount,
-                payload);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeChanged notifyItemRangeChanged}.
+     *
+     * @param section this section
+     * @param positionStart position of the first item that was inserted in the section
+     * @param itemCount number of items inserted in the section
+     * @param payload optional parameter, use null to identify a "full" update
+     */
+    public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount,
+                                                Object payload) {
+        callSuperNotifyItemRangeChanged(getPositionInAdapter(section, positionStart), itemCount, payload);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -518,9 +518,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemRemovedFromSection(String tag, int position) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemRemoved(getPositionInAdapter(tag, position));
+    }
 
-        callSuperNotifyItemRemoved(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + position);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRemoved notifyItemRemoved}.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     */
+    public void notifyItemRemovedFromSection(Section section, int position) {
+        callSuperNotifyItemRemoved(getPositionInAdapter(section, position));
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -414,6 +414,32 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     }
 
     /**
+     * Helper method that receives position in relation to the section, and returns the position in
+     * the adapter.
+     *
+     * @param tag unique identifier of the section
+     * @param position position of the item in the section
+     * @return position of the item in the adapter
+     */
+    public int getPositionInAdapter(String tag, int position) {
+        Section section = getValidSectionOrThrowException(tag);
+
+        return getPositionInAdapter(section, position);
+    }
+
+    /**
+     * Helper method that receives position in relation to the section, and returns the position in
+     * the adapter.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     * @return position of the item in the adapter
+     */
+    public int getPositionInAdapter(Section section, int position) {
+        return getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position;
+    }
+    
+    /**
      * Helper method that receives position in relation to the section, calculates the relative
      * position in the adapter and calls {@link #notifyItemInserted}.
      *

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -488,8 +488,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items inserted in the section
      */
     public void notifyItemRangeInsertedInSection(String tag, int positionStart, int itemCount) {
-        callSuperNotifyItemRangeInserted(
-                getPositionInAdapter(tag, positionStart), itemCount);
+        callSuperNotifyItemRangeInserted(getPositionInAdapter(tag, positionStart), itemCount);
     }
 
     /**
@@ -501,8 +500,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items inserted in the section
      */
     public void notifyItemRangeInsertedInSection(Section section, int positionStart, int itemCount) {
-        callSuperNotifyItemRangeInserted(
-                getPositionInAdapter(section, positionStart), itemCount);
+        callSuperNotifyItemRangeInserted(getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting
@@ -602,10 +600,19 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param itemCount number of items inserted in the section
      */
     public void notifyItemRangeChangedInSection(String tag, int positionStart, int itemCount) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemRangeChanged(getPositionInAdapter(tag, positionStart), itemCount);
+    }
 
-        callSuperNotifyItemRangeChanged(
-                getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + positionStart, itemCount);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemRangeChanged notifyItemRangeChanged}.
+     *
+     * @param section this section
+     * @param positionStart position of the first item that was inserted in the section
+     * @param itemCount number of items inserted in the section
+     */
+    public void notifyItemRangeChangedInSection(Section section, int positionStart, int itemCount) {
+        callSuperNotifyItemRangeChanged(getPositionInAdapter(section, positionStart), itemCount);
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -384,24 +384,37 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @return position of the section in the adapter
      */
     public int getSectionPosition(String tag) {
+        Section section = getValidSectionOrThrowException(tag);
+
+        return getSectionPosition(section);
+    }
+
+
+    /**
+     * Return the section position in the adapter.
+     *
+     * @param section This section
+     * @return position of the section in the adapter
+     */
+    public int getSectionPosition(Section section) {
         int currentPos = 0;
 
         for (Map.Entry<String, Section> entry : sections.entrySet()) {
-            Section section = entry.getValue();
+            Section s = entry.getValue();
 
             // ignore invisible sections
-            if (!section.isVisible()) continue;
+            if (!s.isVisible()) continue;
 
-            int sectionTotal = section.getSectionItemsTotal();
+            int sectionTotal = s.getSectionItemsTotal();
 
-            if (entry.getKey().equalsIgnoreCase(tag)) {
+            if (s == section) {
                 return currentPos;
             }
 
             currentPos += sectionTotal;
         }
 
-        throw new IllegalArgumentException("Invalid tag: " + tag);
+        throw new IllegalArgumentException("Invalid section");
     }
 
     /**
@@ -438,7 +451,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     public int getPositionInAdapter(Section section, int position) {
         return getSectionPosition(section) + (section.hasHeader ? 1 : 0) + position;
     }
-    
+
     /**
      * Helper method that receives position in relation to the section, calculates the relative
      * position in the adapter and calls {@link #notifyItemInserted}.

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -574,9 +574,18 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * @param position position of the item in the section
      */
     public void notifyItemChangedInSection(String tag, int position) {
-        Section section = getValidSectionOrThrowException(tag);
+        callSuperNotifyItemChanged(getPositionInAdapter(tag, position));
+    }
 
-        callSuperNotifyItemChanged(getSectionPosition(tag) + (section.hasHeader ? 1 : 0) + position);
+    /**
+     * Helper method that receives position in relation to the section, calculates the relative
+     * position in the adapter and calls {@link #notifyItemChanged notifyItemChanged}.
+     *
+     * @param section this section
+     * @param position position of the item in the section
+     */
+    public void notifyItemChangedInSection(Section section, int position) {
+        callSuperNotifyItemChanged(getPositionInAdapter(section, position));
     }
 
     @VisibleForTesting

--- a/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapter.java
@@ -393,21 +393,21 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
     /**
      * Return the section position in the adapter.
      *
-     * @param section This section
+     * @param section a visible section of this adapter
      * @return position of the section in the adapter
      */
     public int getSectionPosition(Section section) {
         int currentPos = 0;
 
         for (Map.Entry<String, Section> entry : sections.entrySet()) {
-            Section s = entry.getValue();
+            Section loopSection = entry.getValue();
 
             // ignore invisible sections
-            if (!s.isVisible()) continue;
+            if (!loopSection.isVisible()) continue;
 
-            int sectionTotal = s.getSectionItemsTotal();
+            int sectionTotal = loopSection.getSectionItemsTotal();
 
-            if (s == section) {
+            if (loopSection == section) {
                 return currentPos;
             }
 
@@ -444,7 +444,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * Helper method that receives position in relation to the section, and returns the position in
      * the adapter.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param position position of the item in the section
      * @return position of the item in the adapter
      */
@@ -465,9 +465,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemInserted notifyItemInserted}.
+     * position in the adapter and calls {@link #notifyItemInserted}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param position position of the item in the section
      */
     public void notifyItemInsertedInSection(Section section, int position) {
@@ -493,9 +493,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemRangeInserted notifyItemRangeInserted}.
+     * position in the adapter and calls {@link #notifyItemRangeInserted}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param positionStart position of the first item that was inserted in the section
      * @param itemCount number of items inserted in the section
      */
@@ -521,9 +521,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemRemoved notifyItemRemoved}.
+     * position in the adapter and calls {@link #notifyItemRemoved}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param position position of the item in the section
      */
     public void notifyItemRemovedFromSection(Section section, int position) {
@@ -549,9 +549,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemRangeRemoved notifyItemRangeRemoved}.
+     * position in the adapter and calls {@link #notifyItemRangeRemoved}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param positionStart previous position of the first item that was removed from the section
      * @param itemCount number of items removed from the section
      */
@@ -577,9 +577,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemChanged notifyItemChanged}.
+     * position in the adapter and calls {@link #notifyItemChanged}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param position position of the item in the section
      */
     public void notifyItemChangedInSection(Section section, int position) {
@@ -605,9 +605,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemRangeChanged notifyItemRangeChanged}.
+     * position in the adapter and calls {@link #notifyItemRangeChanged}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param positionStart position of the first item that was inserted in the section
      * @param itemCount number of items inserted in the section
      */
@@ -636,9 +636,9 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
 
     /**
      * Helper method that receives position in relation to the section, calculates the relative
-     * position in the adapter and calls {@link #notifyItemRangeChanged notifyItemRangeChanged}.
+     * position in the adapter and calls {@link #notifyItemRangeChanged}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param positionStart position of the first item that was inserted in the section
      * @param itemCount number of items inserted in the section
      * @param payload optional parameter, use null to identify a "full" update
@@ -670,7 +670,7 @@ public class SectionedRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerV
      * Helper method that receives position in relation to the section, calculates the relative
      * position in the adapter and calls {@link #notifyItemMoved}.
      *
-     * @param section this section
+     * @param section a visible section of this adapter
      * @param fromPosition previous position of the item in the section
      * @param toPosition new position of the item in the section
      */

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -86,6 +86,10 @@ public class SectionedRecyclerViewAdapterTest {
         // Given
         addStatelessSectionStubToAdapter();
 
+        Section invisibleSection = addStatelessSectionStubToAdapter();
+        invisibleSection.setVisible(false);
+        sectionAdapter.addSection(invisibleSection);
+
         sectionAdapter.addSection(SECTION_TAG, new StatelessSectionStub(ITEMS_QTY));
 
         // When
@@ -102,7 +106,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getSectionPositionUsingSection_withInvalidTag_throwsException() {
+    public void getSectionPositionUsingSection_withInvalidSection_throwsException() {
         // Given
         addStatelessSectionStubToAdapter();
         addStatelessSectionStubToAdapter();
@@ -115,6 +119,10 @@ public class SectionedRecyclerViewAdapterTest {
     public void getSectionPositionUsingSection_withAdapterWithInvisibleSection_returnsCorrectPosition() {
         // Given
         addStatelessSectionStubToAdapter();
+
+        Section invisibleSection = addStatelessSectionStubToAdapter();
+        invisibleSection.setVisible(false);
+        sectionAdapter.addSection(invisibleSection);
 
         StatelessSectionStub statelessSectionStub = new StatelessSectionStub(ITEMS_QTY);
 
@@ -443,7 +451,10 @@ public class SectionedRecyclerViewAdapterTest {
         spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, new HeadedFootedStatelessSectionStub(ITEMS_QTY));
 
         // When
-        assertEquals(11, spySectionedRecyclerViewAdapter.getPositionInAdapter(SECTION_TAG, 0));
+        int result = spySectionedRecyclerViewAdapter.getPositionInAdapter(SECTION_TAG, 0);
+
+        // Then
+        assertThat(result, is(11));
     }
 
     @Test
@@ -457,7 +468,10 @@ public class SectionedRecyclerViewAdapterTest {
         spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
 
         // When
-        assertEquals(11, spySectionedRecyclerViewAdapter.getPositionInAdapter(headedFootedStatelessSectionStub, 0));
+        int result = spySectionedRecyclerViewAdapter.getPositionInAdapter(headedFootedStatelessSectionStub, 0);
+
+        // Then
+        assertThat(result, is(11));
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -527,7 +527,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRemovedFromSection_withAdapterWithManySections_callsSuperNotifyItemRemoved() {
+    public void notifyItemRemovedFromSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRemoved() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(anyInt());
@@ -537,6 +537,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRemovedFromSection(SECTION_TAG, 0);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(11);
+    }
+
+    @Test
+    public void notifyItemRemovedFromSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRemoved() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRemovedFromSection(headedFootedStatelessSectionStub, 0);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRemoved(11);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -494,7 +494,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeInsertedInSection_withAdapterWithManySections_callsSuperNotifyItemRangeInserted() {
+    public void notifyItemRangeInsertedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeInserted() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(anyInt(), anyInt());
@@ -504,6 +504,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeInsertedInSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(11, 4);
+    }
+
+    @Test
+    public void notifyItemRangeInsertedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeInserted() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeInsertedInSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeInserted(11, 4);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * @author Gustavo Pagani
  */
@@ -64,13 +66,13 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getSectionPosition_withEmptyAdapter_throwsException() {
+    public void getSectionPositionUsingTag_withEmptyAdapter_throwsException() {
         // When
         sectionAdapter.getSectionPosition(SECTION_TAG);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void getSectionPosition_withInvalidTag_throwsException() {
+    public void getSectionPositionUsingTag_withInvalidTag_throwsException() {
         // Given
         addStatelessSectionStubToAdapter();
         addStatelessSectionStubToAdapter();
@@ -80,7 +82,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void getSectionPosition_withAdapterWithInvisibleSection_returnsCorrectPosition() {
+    public void getSectionPositionUsingTag_withAdapterWithInvisibleSection_returnsCorrectPosition() {
         // Given
         addStatelessSectionStubToAdapter();
 
@@ -88,6 +90,38 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         int result = sectionAdapter.getSectionPosition(SECTION_TAG);
+
+        // Then
+        assertThat(result, is(10));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getSectionPositionUsingSection_withEmptyAdapter_throwsException() {
+        // When
+        sectionAdapter.getSectionPosition(new StatelessSectionStub(ITEMS_QTY));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getSectionPositionUsingSection_withInvalidTag_throwsException() {
+        // Given
+        addStatelessSectionStubToAdapter();
+        addStatelessSectionStubToAdapter();
+
+        // When
+        sectionAdapter.getSectionPosition(new StatelessSectionStub(ITEMS_QTY));
+    }
+
+    @Test
+    public void getSectionPositionUsingSection_withAdapterWithInvisibleSection_returnsCorrectPosition() {
+        // Given
+        addStatelessSectionStubToAdapter();
+
+        StatelessSectionStub statelessSectionStub = new StatelessSectionStub(ITEMS_QTY);
+
+        sectionAdapter.addSection(statelessSectionStub);
+
+        // When
+        int result = sectionAdapter.getSectionPosition(statelessSectionStub);
 
         // Then
         assertThat(result, is(10));
@@ -397,6 +431,33 @@ public class SectionedRecyclerViewAdapterTest {
         // Then
         assertThat(sectionAdapter.getItemCount(), is(0));
         assertTrue(sectionAdapter.getSectionsMap().isEmpty());
+    }
+
+    @Test
+    public void getPositionInAdapterUsingTag_withAdapterWithManySections_returnsCorrectAdapterPosition() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        spySectionedRecyclerViewAdapter.addSection(SECTION_TAG, new HeadedFootedStatelessSectionStub(ITEMS_QTY));
+
+        // When
+        assertEquals(11, spySectionedRecyclerViewAdapter.getPositionInAdapter(SECTION_TAG, 0));
+    }
+
+    @Test
+    public void getPositionInAdapterUsingSection_withAdapterWithManySections_returnsCorrectAdapterPosition() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        assertEquals(11, spySectionedRecyclerViewAdapter.getPositionInAdapter(headedFootedStatelessSectionStub, 0));
     }
 
     @Test

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -692,7 +692,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemMovedInSection_withAdapterWithManySections_callsSuperNotifyItemMoved() {
+    public void notifyItemMovedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemMoved() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(anyInt(), anyInt());
@@ -702,6 +702,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemMovedInSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(11, 15);
+    }
+
+    @Test
+    public void notifyItemMovedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemMoved() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemMovedInSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemMoved(11, 15);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -560,7 +560,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeRemovedInSection_withAdapterWithManySections_callsSuperNotifyItemRangeRemoved() {
+    public void notifyItemRangeRemovedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeRemoved() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(anyInt(), anyInt());
@@ -570,6 +570,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeRemovedFromSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(11, 4);
+    }
+
+    @Test
+    public void notifyItemRangeRemovedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeRemoved() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeRemovedFromSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeRemoved(11, 4);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -593,7 +593,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemChangedInSection_withAdapterWithManySections_callsSuperNotifyItemChangedInSection() {
+    public void notifyItemChangedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemChangedInSection() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(anyInt());
@@ -603,6 +603,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemChangedInSection(SECTION_TAG, 0);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(11);
+    }
+
+    @Test
+    public void notifyItemChangedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemChangedInSection() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemChangedInSection(headedFootedStatelessSectionStub, 0);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemChanged(11);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -461,7 +461,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemInsertedInSection_withAdapterWithManySections_callsSuperNotifyItemInserted() {
+    public void notifyItemInsertedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemInserted() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
@@ -471,6 +471,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemInsertedInSection(SECTION_TAG, 0);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(11);
+    }
+
+    @Test
+    public void notifyItemInsertedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemInserted() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemInsertedInSection(headedFootedStatelessSectionStub, 0);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemInserted(11);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -626,7 +626,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeChangedInSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+    public void notifyItemRangeChangedInSectionUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt());
@@ -636,6 +636,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(SECTION_TAG, 0, 4);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4);
+    }
+
+    @Test
+    public void notifyItemRangeChangedInSectionUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(headedFootedStatelessSectionStub, 0, 4);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4);

--- a/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
+++ b/library/src/test/java/io/github/luizgrp/sectionedrecyclerviewadapter/SectionedRecyclerViewAdapterTest.java
@@ -659,7 +659,7 @@ public class SectionedRecyclerViewAdapterTest {
     }
 
     @Test
-    public void notifyItemRangeChangedInSectionWithPayload_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+    public void notifyItemRangeChangedInSectionWithPayloadUsingTag_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
         // Given
         SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
         doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt(), any());
@@ -669,6 +669,23 @@ public class SectionedRecyclerViewAdapterTest {
 
         // When
         spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(SECTION_TAG, 0, 4, null);
+
+        // Then
+        verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4, null);
+    }
+
+    @Test
+    public void notifyItemRangeChangedInSectionWithPayloadUsingSection_withAdapterWithManySections_callsSuperNotifyItemRangeChanged() {
+        // Given
+        SectionedRecyclerViewAdapter spySectionedRecyclerViewAdapter = spy(SectionedRecyclerViewAdapter.class);
+        doNothing().when(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(anyInt(), anyInt(), any());
+
+        spySectionedRecyclerViewAdapter.addSection(new StatelessSectionStub(ITEMS_QTY));
+        HeadedFootedStatelessSectionStub headedFootedStatelessSectionStub = new HeadedFootedStatelessSectionStub(ITEMS_QTY);
+        spySectionedRecyclerViewAdapter.addSection(headedFootedStatelessSectionStub);
+
+        // When
+        spySectionedRecyclerViewAdapter.notifyItemRangeChangedInSection(headedFootedStatelessSectionStub, 0, 4, null);
 
         // Then
         verify(spySectionedRecyclerViewAdapter).callSuperNotifyItemRangeChanged(11, 4, null);


### PR DESCRIPTION
For methods which are accepting TAG as parameter, I add an alternative to accept Section as well. So that caller need *not* maintain "Section to TAG" mapping, before calling `SectionedRecyclerViewAdapter`