### PR TITLE
BUG: Viewtype is wrong

### DIFF
--- a/app/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/demo/Example5Fragment.java
+++ b/app/src/main/java/io/github/luizgrp/sectionedrecyclerviewadapter/demo/Example5Fragment.java
@@ -41,7 +41,7 @@ public class Example5Fragment extends Fragment {
         glm.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
             @Override
             public int getSpanSize(int position) {
-                switch (sectionAdapter.getSectionItemViewType(position)) {
+                switch (sectionAdapter.getSectionItemViewType(position) % 6) {
                     case SectionedRecyclerViewAdapter.VIEW_TYPE_HEADER:
                         return 2;
                     default:


### PR DESCRIPTION
I was using your library and only the elements at the first and second position(both in 1 section) had the correct ViewType.
For the next positions (New Section) the ViewType was greater than 6 so switch ended up always in the default case.
By adding  `sectionAdapter.getItemViewType(position) % 6` in the switch, the ViewType can actually end up in the 6 different cases that each section can have(header,footer, loaded, empty,loading, failed).